### PR TITLE
import merge method from hardware.generate

### DIFF
--- a/merge.py
+++ b/merge.py
@@ -22,7 +22,7 @@
 import sys
 from yaml import dump, load
 
-from hardware import merge
+from hardware import generate
 
 
 def main():
@@ -30,7 +30,7 @@ def main():
     vars_ = {}
     for fname in sys.argv[1:]:
         current = load(open(fname).read())
-        merge.merge(vars_, current)
+        generate.merge(vars_, current)
     sys.stdout.write(dump(vars_))
 
 if __name__ == "__main__":


### PR DESCRIPTION
merge() method used to be in hardware.merge module. As in hardware 0.7,
it's hardware.generate.