### PR TITLE
pull tagged puppet-openstack-cloud from eno repo

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -311,6 +311,7 @@ else
     git --git-dir=puppet-module/.git rev-parse HEAD > $TOP/etc/config-tools/puppet-module-rev
     wget https://raw.githubusercontent.com/redhat-openstack/openstack-puppet-modules/enovance/Puppetfile -O ./puppet-module/Puppetfile
     if [ -n "$tag" -a "$tagged" = 1 ]; then
+        sed -i -e "s,git://github.com/stackforge/puppet-openstack-cloud.git,git://github.com/enovance/puppet-openstack-cloud.git," ./puppet-module/Puppetfile
         sed -i -e "s/master/$(cat ${TOP}/etc/config-tools/puppet-module-rev)/" ./puppet-module/Puppetfile
     fi
     if [ "$LOCAL" != 1 ]; then


### PR DESCRIPTION
For J.1.0.0, the official tagged release will be pushed on
stackforge puppet-openstack-cloud.git repository. For the moment we
still have to pull them from
git://github.com/enovance/puppet-openstack-cloud.git

For example, today the I.1.2.1 and I.1.3.0 tags only exist in the eNovance
repository.