### PR TITLE
preserve edeploy key for backward compatibility

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -150,7 +150,7 @@ update_or_clone "$envgit" env
 puppetgit=$($ORIG/extract.py module "$yamlfile")
 puppetmodules=$($ORIG/extract.py puppetmodules "$yamlfile"|sed -e "s/@VERSION@/$version/")
 serverspecgit=$($ORIG/extract.py serverspec "$yamlfile")
-edeploygit=$($ORIG/extract.py edeploy "$yamlfile")
+edeploygit=$($ORIG/extract.py edeploy_repo "$yamlfile")
 env=$($ORIG/extract.py environment "$yamlfile")
 envyml=${env}.yml
 infragit=$($ORIG/extract.py infrastructure "$yamlfile")
@@ -167,7 +167,7 @@ ansiblegit=$($ORIG/extract.py ansible "$yamlfile")
 kernel=$($ORIG/extract.py kernel "$yamlfile"|sed -e "s/@VERSION@/$version/")
 pxe=$($ORIG/extract.py pxeramdisk "$yamlfile"|sed -e "s/@VERSION@/$version/")
 health=$($ORIG/extract.py healthramdisk "$yamlfile"|sed -e "s/@VERSION@/$version/")
-rolesurl=$($ORIG/extract.py roles "$yamlfile"|sed -e "s/@VERSION@/$version/")
+rolesurl=$($ORIG/extract.py edeploy "$yamlfile"|sed -e "s/@VERSION@/$version/")
 jenkinsgit=$($ORIG/extract.py jenkins "$yamlfile")
 scenario=$($ORIG/extract.py scenario "$yamlfile")
 


### PR DESCRIPTION
So far, the environments were coming with a edeploy key. This key was
use to point on the .edeploy file location.

With this incoming release, the purpose of this edeploy has been
changed. It's not the location of the eDeploy git repository.
The .edeploy file location are now pointed by the newly introduced roles key.

Our problem is simple, it will be impossible to use code from the
master branch against env from previous release. The opposite is also
true.

We believe it's would make sense to preserve the edeploy key unchanged
and introduce a new edeploy_repo to point on the location of the edeploy
git repository.

See:
 - caf96e2982dddb5a8c532238564a0038eaa7ee27
 - 29b9b5726bbc99ee0ff1c9a823fc81b0b3f4394b

This fixes #44