### PR TITLE
download.sh: fix the logic with ansiblegit

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -300,9 +300,10 @@ if [ -n "$ansiblegit" ]; then
     clone "$ansiblegit" ansible
     mkdir -p $TOP/etc/ansible
     if [ -z "$stable" ]; then
-      echo "Please indicate to provision.sh stable=<latest stable release>."
+        echo "Please indicate to download.sh stable=<latest stable release>."
+    else
+        cp -a ansible/upgrade/$stable/$tag/* $TOP/etc/ansible/
     fi
-    cp -a ansible/upgrade/$stable/$tag/* $TOP/etc/ansible/
 fi
 
 # hosts


### PR DESCRIPTION
Do not fail if `$stable` is not defined. I think this was actually the
expected behavior.