### PR TITLE
extract-archive: untar only if archive.tar is here

### DIFF
--- a/extract-archive.sh
+++ b/extract-archive.sh
@@ -22,6 +22,7 @@ set -x
 ORIG=$(cd $(dirname $0); pwd)
 . $ORIG/functions
 
+TARBALL_ARCHIVE="/tmp/archive.tar"
 SUDO_USER=${SUDO_USER:=root}
 
 if [ -r /etc/redhat-release ]; then
@@ -30,9 +31,11 @@ else
     USER=www-data
 fi
 
-rm -rf /etc/edeploy/*
 
-tar xf /tmp/archive.tar --no-same-owner -C /
+if [ -f $TARBALL_ARCHIVE ]; then
+    rm -rf /etc/edeploy/*
+    tar xf /tmp/archive.tar --no-same-owner -C /
+fi
 chown -R $SUDO_USER /etc/serverspec
 
 if [ ${SUDO_USER} != root ]; then


### PR DESCRIPTION
Only extract archive.tar if the file in the machine. When possible, it's
more efficient to directly rsync the content of the tarball from the
remote host. This instead of doing a scp of the tarball then an untar in
the remote host.

(cherry picked from commit 4c7e2452bd6eddb74d4f6a4dea04170724a63c89)