### PR TITLE
configure: Run final verify only if step 1 has been run

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -358,7 +358,10 @@ for (( step=$STEP; step<=$LAST; step++)); do # Yep, this is a bashism
     fi
 done
 
-verify-servers.sh -x $LOGDIR
+last_step=$(cat $CDIR/step)
+if [ $last_step -gt 1 ]; then
+    verify-servers.sh -x $LOGDIR
+fi
 
 # ensure logs are readable by Jenkins
 chmod -R 644 $LOGDIR/*


### PR DESCRIPTION
Run the final verify-server.sh *only* if step1 has been run.
If it is run only when step0 has been run, it will generate an arch.yml
file according to components supposed to be in step1 and not step0
leading to a permanent failure.