### PR TITLE
extract-archive: ensure tar 1.27 is installed

### DIFF
--- a/extract-archive.sh
+++ b/extract-archive.sh
@@ -29,6 +29,13 @@ if [ -r /etc/redhat-release ]; then
     USER=apache
 else
     USER=www-data
+    # workaround for Debian old tar package which doesn't support --xattrs
+    # can be dropped after J.1.0.0 released
+    if ! tar --usage | egrep 'xattrs'; then
+      curl -o /tmp/tar.dev http://ftp.debian.org/debian/pool/main/t/tar/tar_1.27.1-1~bpo70+1_amd64.deb
+      dpkg -i /tmp/tar.deb
+      rm -f /tmp/tar.deb
+    fi
 fi
 
 


### PR DESCRIPTION
In Debian Wheezy, tar does not support --xattrs (will be supported in
Jessie).

It has been patched in eDeploy roles for J.1.0.0
fdb275f03ab4291aa68f15c8f75c149b5e6d16e2

But during the upgrade process, we need to ensure install-server I.1.3.0 can extract the archive with this option.
This patch will be reverted after J.1.0.0.