### PR TITLE
Removes old images from glance in inception.sh

### DIFF
--- a/inception.sh
+++ b/inception.sh
@@ -84,6 +84,8 @@ for name in install-server-$dist-$release openstack-full-$dist-$release; do
     wget -q $imageurl/$name.img.md5
     md5img=$(cut -f1 -d' ' < $name.img.md5|sed 's/ *//g')
     if [ "$md5glance" != "$md5img" ]; then
+	# if there's a previous image with the same name, delete it
+	[ -n "$md5glance" ] && glance --insecure image-delete $name
         wget -q -O $name.img $imageurl/$name.img
         md5sum -c $name.img.md5
         glance --insecure image-create --name $name --container-format bare --disk-format raw < $name.img


### PR DESCRIPTION
If an image exists with the same name as the role, but has a different
hash, it will remain in place. Inception will then create a new image
with a different name, which leads to some issues.

This patch makes sure that the old image is removed before adding the
new one in glance