### PR TITLE
Fix generate error display when your arity is not respected.

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -176,7 +176,7 @@ if __name__ == "__main__":
                               open(sys.argv[3]).read(),
                               overwrite)
     except Invalid, excpt:
-        print excpt
+        sys.stderr.write('%s\n' % excpt)
         sys.exit(1)
 
 # generate.py ends here


### PR DESCRIPTION
My provision stop on this line (no error but stop) :

```
./provision.sh ...
+ .../config-tools/generate.py 0 ...config-tools/global.yml ...config-tools/config.tmpl ... > $TOP/etc/config-tools/config
```

This fix change printed error to stderr :

```
Not the expected arity (3+2n) for controller: 0
```

The result is :

```
generate.py 0 ... > /dev/null
Not the expected arity (3+2n) for controller: 0
```