### PR TITLE
generate.py: Backport fix on generate_dict

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -272,7 +272,7 @@ def generate_dict(model):
             for newkey, val in izip(list(_generate_values(key)),
                                     generate_list(model[thekey])):
                 try:
-                    result[newkey] = merge(result[key], val)
+                    result[newkey] = merge(result[newkey], val)
                 except KeyError:
                     result[newkey] = val
         else:


### PR DESCRIPTION
When using I.1.3.0 with range in the environment file (=node1-3) the overrides
on fqdn (ex: rbd:key) are not merge with the configuration in the range.

The fix was pushed to hardware python module but config-tools in I.1.3.0 doesn't
use it.

https://github.com/enovance/hardware/commit/7a21558fb42e719d8cb9acab9cb9c96c04964cfd

The hardware python module was introduced in J.1.x series.

https://github.com/enovance/config-tools/commit/6f4c2b22572ccdc85bf44d9381cb3ca0f2615458