### PR TITLE
configure: set 10 min timeout to Puppet catalog compilation

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -165,7 +165,7 @@ run_puppet() {
     loop=$3
 
     logfile="${LOGDIR}/${h}.step${step}.try${loop}.log"
-    puppet_cmdline="puppet apply ${PUPPETOPTS} /etc/puppet/manifest.pp"
+    puppet_cmdline="timeout 600 puppet apply ${PUPPETOPTS} /etc/puppet/manifest.pp"
     ssh_puppet_cmdline="ssh $SSHOPTS $USER@$h sudo -i ${puppet_cmdline}"
 
     if run_parallel $step; then
@@ -180,6 +180,9 @@ run_puppet() {
         else
             ${ssh_puppet_cmdline} 2>&1 | tee ${logfile}
         fi
+    fi
+    if [ $? -eq 124 ]; then
+       echo "Timeout (10 minutes) on $h step $step try $loop"
     fi
 }
 


### PR DESCRIPTION
Setup a timeout to compile the Puppet catalog in less than 10 minutes.
A deployment should not have Puppet steps during more than 10 minutes,
we should fail before to prevent a too-long deployment.