### PR TITLE
config.tmpl: Sort hosts in config template

### DIFF
--- a/config.tmpl
+++ b/config.tmpl
@@ -1,11 +1,11 @@
 DOMAIN={{ config.domain }}
-HOSTS="{% for profile in ordered_profiles %}{% for hname in hosts%}{% if hosts[hname].profile == profile %}{{ hname }} {% endif %}{% endfor %}{% endfor %}"
+HOSTS="{% for profile in ordered_profiles %}{% for hname in hosts|sort %}{% if hosts[hname].profile == profile %}{{ hname }} {% endif %}{% endfor %}{% endfor %}"
 USER={{ config.user }}
 MASTER=${MASTER:={{ config.puppet_master }}}
 PARALLELSTEPS="{{ config.parallel_steps }}"
 PROFILES="{% for profile in ordered_profiles %}{{ profile }} {% endfor %}"
 declare -A PROF_BY_HOST
-{% for profile in ordered_profiles %}{% for hname in hosts%}{% if hosts[hname].profile == profile %}PROF_BY_HOST["{{ hname }}"]="{{ profile }}"
+{% for profile in ordered_profiles %}{% for hname in hosts|sort %}{% if hosts[hname].profile == profile %}PROF_BY_HOST["{{ hname }}"]="{{ profile }}"
 {% endif %}{% endfor %}{% endfor %}
 EDEPLOY_VERSION={{ version }}
 EDEPLOY_ROLE={{ role }}


### PR DESCRIPTION
In most of cases we use ordered numbers with  hostname and we use the first
controller as the galera master node.

Currently the host list generated is not sorted so we are not sure that
the first controller will be the first to run puppet. In that case we need to
wait the galera bootstrap timeout on the other controller nodes (~10min).

```
./generate.py 0 global.yml config.tmpl
(...)
HOSTS="install-server node302 node300 node301 node306 node307 "
```
This patch allow to sort the host list and reduce the time on step 1 for
the galera bootstrap.
```
./generate.py 0 global.yml config.tmpl
(...)
HOSTS="install-server node300 node301 node302 node306 node307 "
```