### PR TITLE
download.sh: Fix substitution for puppetmodules J.1.0

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -148,7 +148,7 @@ yamlfile=env/$(basename $yaml)
 update_or_clone "$envgit" env
 
 puppetgit=$($ORIG/extract.py module "$yamlfile")
-puppetmodules=$($ORIG/extract.py puppetmodules "$yamlfile"|sed -e "s/@VERSION@/$version/")
+puppetmodules=$($ORIG/extract.py puppetmodules "$yamlfile"|sed -e "s/@VERSION@/$tag/g")
 serverspecgit=$($ORIG/extract.py serverspec "$yamlfile")
 edeploygit=$($ORIG/extract.py edeploy_repo "$yamlfile")
 env=$($ORIG/extract.py environment "$yamlfile")


### PR DESCRIPTION
When using puppetmodules with tarball instead of git repository the version is
not related to the distribution (RH7.0, D7, etc..) so we just need to use tag
instead of version.

<host>/spinal-stack/J.1.0.0/puppet-openstack-cloud-J.1.0.0.tgz
<host>/spinal-stack/@VERSION@/puppet-openstack-cloud-@VERSION@.tgz