### PR TITLE
download.sh: Fix substitution for puppetmodules I.1.3

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -144,7 +144,7 @@ yamlfile=env/$(basename $yaml)
 update_or_clone "$envgit" env
 
 puppetgit=$($ORIG/extract.py module "$yamlfile")
-puppetmodules=$($ORIG/extract.py puppetmodules "$yamlfile"|sed -e "s/@VERSION@/$version/")
+puppetmodules=$($ORIG/extract.py puppetmodules "$yamlfile"|sed -e "s/@VERSION@/$tag/g")
 serverspecgit=$($ORIG/extract.py serverspec "$yamlfile")
 env=$($ORIG/extract.py environment "$yamlfile")
 envyml=${env}.yml


### PR DESCRIPTION
When using puppetmodules with tarball instead of git repository the version is
not related to the distribution (RH7.0, D7, etc..) so we just need to use tag
instead of version.

<host>/spinal-stack/J.1.0.0/puppet-openstack-cloud-J.1.0.0.tgz
<host>/spinal-stack/@VERSION@/puppet-openstack-cloud-@VERSION@.tgz