### PR TITLE
send.sh: Don't rsync when provisionning from IS

### DIFF
--- a/send.sh
+++ b/send.sh
@@ -34,12 +34,16 @@ if tty -s; then
     ROPTS=-vP
 fi
 
-rsync -e "ssh $SSHOPTS" -az $ROPTS archive.tar functions extract-archive.sh $USER@$MASTER:/tmp/
-
 if [ $USER != root ]; then
     SUDO=sudo
 fi
 
-ssh $SSHOPTS $USER@$MASTER $SUDO /tmp/extract-archive.sh
+if [ "${PROF_BY_HOST[$HOSTNAME]}" == "install-server" ]; then
+    cp -a archive.tar functions extract-archive.sh /tmp/
+    $SUDO /tmp/extract-archive.sh
+else
+    rsync -e "ssh $SSHOPTS" -az $ROPTS archive.tar functions extract-archive.sh $USER@$MASTER:/tmp/
+    ssh $SSHOPTS $USER@$MASTER $SUDO /tmp/extract-archive.sh
+fi
 
 # send.sh ends here


### PR DESCRIPTION
When using the install-server node to do the provisionning, the send.sh script
will send the tarball to itself with rsync+ssh.

To reduce this time to seconds (instead of some minutes) we just need to copy
the files in /tmp directory.

```
# time send.sh
local copy : ~ 2.65s
rsync+ssh  : ~ 1m30
```